### PR TITLE
Support npm Trusted Publishing with OIDC authentication

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,15 +13,17 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
+          registry-url: "https://registry.npmjs.org"
       - name: Setup Git User
         run: |
           git config --local user.email "github-actions@github.com"
@@ -38,7 +40,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npm run release --ci --increment $RELEASE_TYPE
       - name: make pull-request to ready
         env:


### PR DESCRIPTION
## Summary

- npm Trusted Publishing (OIDC) に対応するため `package.yml` を更新
- `id-token: write` 権限を追加し、OIDC トークン生成を有効化
- `actions/setup-node` を v5 に更新し、`registry-url` を追加
- `NPM_TOKEN` 環境変数を削除（OIDC 認証では不要）

## 関連

- 参考: https://docs.npmjs.com/trusted-publishers
- serendie/serendie での対応: https://github.com/serendie/serendie/pull/130

## 呼び出し元リポジトリでの対応

1. npmjs.com で Trusted Publisher を設定

## Test plan

- [ ] serendie/serendie で release-it の provenance 設定を追加
- [ ] npmjs.com で Trusted Publisher を設定
- [ ] テストリリースを実行し、provenance が付与されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)