### PR TITLE
chore: support npm Trusted Publishing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       packages: write
       pull-requests: write
     steps:
@@ -19,9 +20,11 @@ jobs:
           fetch-depth: 0
           ref: main
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
       - name: Setup Git User
         run: |
           git config --local user.email "github-actions@github.com"
@@ -36,7 +39,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npm run release --ci --increment $RELEASE_TYPE
       - name: make pull-request to ready
         env:


### PR DESCRIPTION
## 概要
- reusable workflow の release 経路を npm Trusted Publishing / OIDC 前提に更新
- `id-token: write` を追加
- `actions/setup-node` を v6 / Node 24 に更新し、npm registry を明示
- release step から長期 `NPM_TOKEN` の受け渡しを削除

## 呼び出し側で必要な対応
- caller workflow にも `id-token: write` を付与
- 各 package repo の release-it 設定で `npm.skipChecks: true` を設定
- npmjs.com の package settings で Trusted Publisher を登録

## 確認
- workflow YAML parse
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/serendie/.github/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->