### PR TITLE
chore: fix release workflow command

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
@@ -39,7 +39,7 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: npm run release --ci --increment $RELEASE_TYPE
+        run: npm run release -- --ci --increment "$RELEASE_TYPE"
       - name: make pull-request to ready
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
- reusable package workflow の release command に `--` を追加し、`--ci` / `--increment` を release-it に正しく渡すよう修正
- `actions/checkout` を v6 に更新
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/serendie/.github/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->